### PR TITLE
add accept: application/json header to UAA login 

### DIFF
--- a/src/CloudFoundry.CloudController.Test.Integration/AuthTest.cs
+++ b/src/CloudFoundry.CloudController.Test.Integration/AuthTest.cs
@@ -27,7 +27,7 @@ namespace CloudFoundry.CloudController.Test.Integration
             credentials.Password = TestUtil.Password;
 
             var client = TestUtil.GetClient();
-            var authEndpoint = client.Info.GetInfo().Result.TokenEndpoint;
+            var authEndpoint = client.Info.GetInfo().Result.AuthorizationEndpoint;
             var authUri = new Uri(authEndpoint.TrimEnd('/') + "/oauth/token");
 
 
@@ -58,7 +58,7 @@ namespace CloudFoundry.CloudController.Test.Integration
             credentials.Password = TestUtil.Password;
 
             var client = TestUtil.GetClient();
-            var authEndpoint = client.Info.GetInfo().Result.TokenEndpoint;
+            var authEndpoint = client.Info.GetInfo().Result.AuthorizationEndpoint;
             var authUri = new Uri(authEndpoint.TrimEnd('/') + "/oauth/token");
 
 

--- a/src/CloudFoundry.CloudController.Test.Integration/TestUtil.cs
+++ b/src/CloudFoundry.CloudController.Test.Integration/TestUtil.cs
@@ -44,7 +44,7 @@ namespace CloudFoundry.CloudController.Test.Integration
         {
             var cfclient = GetClient();
             var serverInfo = cfclient.Info.GetInfo().Result;
-            var authEndpoint = serverInfo.TokenEndpoint;
+            var authEndpoint = serverInfo.AuthorizationEndpoint;
 
             var authUri = new Uri(authEndpoint.TrimEnd('/') + "/oauth/token");
 

--- a/src/CloudFoundry.CloudController.V2.Client/CloudfoundryClient.cs
+++ b/src/CloudFoundry.CloudController.V2.Client/CloudfoundryClient.cs
@@ -352,7 +352,7 @@ namespace CloudFoundry.CloudController.V2.Client
         {
             var info = await this.Info.GetInfo();
 
-            var authUrl = info.TokenEndpoint.TrimEnd('/') + "/oauth/token";
+            var authUrl = info.AuthorizationEndpoint.TrimEnd('/') + "/oauth/token";
             this.UAAClient = new UAAClient(new Uri(authUrl), this.HttpProxy, this.SkipCertificateValidation);
 
             var context = await this.UAAClient.Login(credentials);
@@ -399,7 +399,7 @@ namespace CloudFoundry.CloudController.V2.Client
         {
             var info = await this.Info.GetInfo();
 
-            var authUrl = info.TokenEndpoint.TrimEnd('/') + "/oauth/token";
+            var authUrl = info.AuthorizationEndpoint.TrimEnd('/') + "/oauth/token";
             this.UAAClient = new UAAClient(new Uri(authUrl), this.HttpProxy, this.SkipCertificateValidation);
 
             var context = await this.UAAClient.Login(refreshToken);

--- a/src/CloudFoundry.UAA.Client.Net45/CloudFoundry.UAA.Client.Net45.csproj
+++ b/src/CloudFoundry.UAA.Client.Net45/CloudFoundry.UAA.Client.Net45.csproj
@@ -73,6 +73,9 @@
     <Compile Include="..\CloudFoundry.UAA.Client\Authentication\IAuthentication.cs">
       <Link>Authentication\IAuthentication.cs</Link>
     </Compile>
+    <Compile Include="..\CloudFoundry.UAA.Client\Authentication\AcceptHeaderOverrideHttpClientHandler.cs">
+      <Link>Authentication\AcceptHeaderOverrideHttpClientHandler.cs</Link>
+    </Compile>
     <Compile Include="..\CloudFoundry.UAA.Client\Authentication\ThinkTectureAuthentication.cs">
       <Link>Authentication\ThinkTectureAuthentication.cs</Link>
     </Compile>

--- a/src/CloudFoundry.UAA.Client/Authentication/AcceptHeaderOverrideHttpClientHandler.cs
+++ b/src/CloudFoundry.UAA.Client/Authentication/AcceptHeaderOverrideHttpClientHandler.cs
@@ -1,0 +1,28 @@
+﻿namespace CloudFoundry.UAA.Authentication
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using CloudFoundry.CloudController.Common.Http;
+
+    internal class AcceptHeaderOverrideHttpClientHandler : PlatformBaseHttpClientHandler
+    {
+        public string OverrideAcceptHeader { get; set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrWhiteSpace(this.OverrideAcceptHeader))
+            {
+                request.Headers.Add("Accept", this.OverrideAcceptHeader);
+            }
+
+            return await base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/src/CloudFoundry.UAA.Client/Authentication/ThinkTectureAuthentication.cs
+++ b/src/CloudFoundry.UAA.Client/Authentication/ThinkTectureAuthentication.cs
@@ -51,13 +51,14 @@
                 throw new ArgumentNullException("credentials");
             }
 
-            using (var httpClientHandler = new PlatformBaseHttpClientHandler())
+            using (var httpClientHandler = new AcceptHeaderOverrideHttpClientHandler())
             {
                 if (this.httpProxy != null)
                 {
                     httpClientHandler.Proxy = new SimpleProxy(this.httpProxy);
                 }
 
+                httpClientHandler.OverrideAcceptHeader = "application/json";
                 httpClientHandler.SkipCertificateValidation = this.skipCertificateValidation;
 
                 var client = new OAuth2Client(this.oauthTarget, this.oauthClient, this.oauthSecret, httpClientHandler);
@@ -132,13 +133,14 @@
 
         private async Task<TokenResponse> RefreshToken(string refreshToken)
         {
-            using (var httpClientHandler = new PlatformBaseHttpClientHandler())
+            using (var httpClientHandler = new AcceptHeaderOverrideHttpClientHandler())
             {
                 if (this.httpProxy != null)
                 {
                     httpClientHandler.Proxy = new SimpleProxy(this.httpProxy);
                 }
 
+                httpClientHandler.OverrideAcceptHeader = "application/json";
                 httpClientHandler.SkipCertificateValidation = this.skipCertificateValidation;
 
                 var client = new OAuth2Client(this.oauthTarget, this.oauthClient, this.oauthSecret, httpClientHandler);

--- a/src/CloudFoundry.UAA.Client/CloudFoundry.UAA.Client.csproj
+++ b/src/CloudFoundry.UAA.Client/CloudFoundry.UAA.Client.csproj
@@ -54,6 +54,7 @@
     </CodeAnalysisDictionary>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Authentication\AcceptHeaderOverrideHttpClientHandler.cs" />
     <Compile Include="Authentication\IAuthentication.cs" />
     <Compile Include="Authentication\ThinkTectureAuthentication.cs" />
     <Compile Include="Authentication\Token.cs" />


### PR DESCRIPTION
and all also use AuthorizationEndpoint inseatead of TokenEndpoint. fix for https://github.com/cloudfoundry-incubator/cf-dotnet-sdk/issues/62
