### PR TITLE
Fix reference not set exception when value is null in manifest

### DIFF
--- a/src/CloudFoundry.CloudController.V2.Client.Test/CloudFoundry.CloudController.V2.Client.Test.csproj
+++ b/src/CloudFoundry.CloudController.V2.Client.Test/CloudFoundry.CloudController.V2.Client.Test.csproj
@@ -236,6 +236,9 @@
     <None Include="Manifests\inherited.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Manifests\manifest_null_value.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Manifests\manifest.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/CloudFoundry.CloudController.V2.Client.Test/Manifests/ManifestTest.cs
+++ b/src/CloudFoundry.CloudController.V2.Client.Test/Manifests/ManifestTest.cs
@@ -108,5 +108,32 @@ namespace CloudFoundry.CloudController.V2.Client.Test.Manifests
             Assert.AreEqual(1, apps.Length);
             Assert.IsTrue(apps[0].NoRoute);
         }
+
+        [TestMethod]
+        public void TestNullValues()
+        {
+
+            Manifest man = ManifestDiskRepository.ReadManifest(Path.Combine(testPath, "Manifests", "manifest_null_value.yaml"));
+
+            Application[] apps = man.Applications();
+            Assert.AreEqual(1, apps.Length);
+            Assert.AreEqual("app-name", apps[0].Name);
+            Assert.AreEqual(128, apps[0].Memory);
+            Assert.AreEqual(1, apps[0].InstanceCount);
+            Assert.AreEqual(1, apps[0].Hosts.Count);
+            Assert.AreEqual(1, apps[0].Domains.Count);
+            Assert.AreEqual("home", apps[0].Hosts[0]);
+            Assert.AreEqual("app.example.com", apps[0].Domains[0]);
+            Assert.AreEqual(@"c:\path\to\app", apps[0].Path);
+            Assert.AreEqual(2, apps[0].EnvironmentVariables.Count);
+            Assert.AreEqual("first", apps[0].EnvironmentVariables["env1"]);
+            Assert.IsNull(apps[0].BuildpackUrl);
+            Assert.IsNull(apps[0].StackName);
+            Assert.AreEqual(500, apps[0].HealthCheckTimeout);
+            Assert.AreEqual("cmd", apps[0].Command);
+            Assert.AreEqual(2, apps[0].Services.Count);
+            Assert.AreEqual(1024, apps[0].DiskQuota);
+            Assert.AreNotEqual(-1, apps[0].Services.IndexOf("mysql"));
+        }
     }
 }

--- a/src/CloudFoundry.CloudController.V2.Client.Test/Manifests/manifest_null_value.yaml
+++ b/src/CloudFoundry.CloudController.V2.Client.Test/Manifests/manifest_null_value.yaml
@@ -1,0 +1,21 @@
+---
+applications:
+- name: app-name
+  memory: 128M
+  disk_quota: 1GB
+  instances: 1
+  buildpack: 
+  timeout: 500
+  command: cmd
+  stack: 
+  services:
+  - mysql
+  - mssql
+  hosts:
+  - home
+  domains:
+  - app.example.com
+  path: c:\path\to\app
+  env: 
+    env1: first
+    env2: second

--- a/src/CloudFoundry.Manifests/Manifest.cs
+++ b/src/CloudFoundry.Manifests/Manifest.cs
@@ -431,6 +431,11 @@
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Justification = "Manifest uses lower case keys")]
         private object ExpandProperties(object input)
         {
+            if (input == null)
+            {
+                return null;
+            }
+
             object output = null;
             Type type = input.GetType();
             if (type == typeof(string))


### PR DESCRIPTION
This fixes a problem if the manifest has a key with an empty value