### PR TITLE
Use only unix file separator for cached files refs

### DIFF
--- a/src/CloudFoundry.CloudController.Common.Net45/PushTools/AppPushTools.cs
+++ b/src/CloudFoundry.CloudController.Common.Net45/PushTools/AppPushTools.cs
@@ -33,7 +33,13 @@
                 FileInfo fileInfo = new FileInfo(file);
                 FileFingerprint print = new FileFingerprint();
                 print.Size = fileInfo.Length;
-                print.FileName = fileInfo.FullName.Replace(appPath, string.Empty).TrimStart('\\');
+                print.FileName = fileInfo.FullName.Substring(appPath.Length).TrimStart('\\');
+                
+                if (Path.DirectorySeparatorChar == '\\')
+                {
+                    print.FileName = print.FileName.Replace(Path.DirectorySeparatorChar, '/');   
+                }
+
                 print.SHA1 = await this.CalculateSHA1(fileInfo.FullName, cancellationToken);
 
                 if (fingerprints.ContainsKey(print.SHA1))


### PR DESCRIPTION
I had problems when pushing a Starter Express Node.js App from VS on a cflinux2 stack. The first push worked on a CF instance, but subsequent pushes will fail to start the app. This patch seams to fix the problem.

I only ran the tests on a cf-release deployment.