### PR TITLE
Add useStrictStatusCodeChecking in cf client

### DIFF
--- a/src/CloudFoundry.CloudController.Common/CloudFoundryClient.cs
+++ b/src/CloudFoundry.CloudController.Common/CloudFoundryClient.cs
@@ -52,14 +52,29 @@ namespace CloudFoundry.CloudController.Common
         /// <param name="httpProxy">The HTTP proxy.</param>
         /// <param name="skipCertificateValidation">if set to <c>true</c> it will skip TLS certificate validation for HTTP requests.</param>
         /// <param name="authorizationUrl">Authorization Endpoint</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "This method is implemented by sealed cf clients")]
         protected CloudFoundryClient(Uri cloudTarget, CancellationToken cancellationToken, Uri httpProxy, bool skipCertificateValidation, Uri authorizationUrl)
+            : this(cloudTarget, cancellationToken, httpProxy, skipCertificateValidation, authorizationUrl, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CloudFoundryClient" /> class.
+        /// </summary>
+        /// <param name="cloudTarget">The cloud target.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="httpProxy">The HTTP proxy.</param>
+        /// <param name="skipCertificateValidation">if set to <c>true</c> it will skip TLS certificate validation for HTTP requests.</param>
+        /// <param name="authorizationUrl">Authorization Endpoint</param>
+        /// <param name="useStrictStatusCodeChecking">Throw exception if the successful http status code returned from the server does not match the expected code</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "This method is implemented by sealed cf clients")]
+        protected CloudFoundryClient(Uri cloudTarget, CancellationToken cancellationToken, Uri httpProxy, bool skipCertificateValidation, Uri authorizationUrl, bool useStrictStatusCodeChecking)
         {
             this.CloudTarget = cloudTarget;
             this.CancellationToken = cancellationToken;
             this.HttpProxy = httpProxy;
             this.SkipCertificateValidation = skipCertificateValidation;
             this.AuthorizationEndpoint = authorizationUrl;
+            this.UseStrictStatusCodeChecking = useStrictStatusCodeChecking;
 
             this.InitEndpoints();
         }
@@ -88,6 +103,11 @@ namespace CloudFoundry.CloudController.Common
         /// Skip Validation
         /// </summary>
         public bool SkipCertificateValidation { get; protected set; }
+
+        /// <summary>
+        /// Skip Validation
+        /// </summary>
+        public bool UseStrictStatusCodeChecking { get; protected set; }
 
         /// <summary>
         /// Initializes all API Endpoints

--- a/src/CloudFoundry.CloudController.V2.Client/BaseEndpoint.cs
+++ b/src/CloudFoundry.CloudController.V2.Client/BaseEndpoint.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using CloudFoundry.CloudController.Common.Exceptions;
@@ -52,7 +53,13 @@
         {
             var result = await client.SendAsync();
 
-            if (((int)result.StatusCode) != expectedReturnStatus)
+            bool success = ((int)result.StatusCode) == expectedReturnStatus;
+            if (!success && !this.Client.UseStrictStatusCodeChecking)
+            {
+                success = IsSuccessStatusCode(result.StatusCode);
+            }
+
+            if (!success)
             {
                 // Check if we can deserialize the response
                 CloudFoundryException cloudFoundryException;
@@ -75,6 +82,11 @@
             }
 
             return result;
+        }
+
+        private static bool IsSuccessStatusCode(HttpStatusCode statusCode)
+        {
+            return statusCode >= HttpStatusCode.OK && statusCode < HttpStatusCode.MultipleChoices;
         }
     }
 }

--- a/src/CloudFoundry.CloudController.V3.Client/BaseEndpoint.cs
+++ b/src/CloudFoundry.CloudController.V3.Client/BaseEndpoint.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using CloudFoundry.CloudController.Common.Exceptions;
@@ -51,7 +52,13 @@
         {
             var result = await client.SendAsync();
 
-            if (((int)result.StatusCode) != expectedReturnStatus)
+            bool success = ((int)result.StatusCode) == expectedReturnStatus;
+            if (!success && !this.Client.UseStrictStatusCodeChecking)
+            {
+                success = IsSuccessStatusCode(result.StatusCode);
+            }
+
+            if (!success)
             {
                 // Check if we can deserialize the response
                 CloudFoundryException cloudFoundryException;
@@ -74,6 +81,11 @@
             }
 
             return result;
+        }
+
+        private static bool IsSuccessStatusCode(HttpStatusCode statusCode)
+        {
+            return statusCode >= HttpStatusCode.OK && statusCode < HttpStatusCode.MultipleChoices;
         }
     }
 }

--- a/src/CloudFoundry.CloudController.V3.Client/CloudFoundryClient.cs
+++ b/src/CloudFoundry.CloudController.V3.Client/CloudFoundryClient.cs
@@ -43,7 +43,7 @@ namespace CloudFoundry.CloudController.V3.Client
             : this(cloudTarget, cancellationToken, httpProxy, skipCertificateValidation, null)
         {
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CloudFoundryClient" /> class.
         /// </summary>
@@ -53,7 +53,21 @@ namespace CloudFoundry.CloudController.V3.Client
         /// <param name="skipCertificateValidation">if set to <c>true</c> it will skip TLS certificate validation for HTTP requests.</param>
         /// <param name="authorizationUrl">Authorization Endpoint</param>
         public CloudFoundryClient(Uri cloudTarget, CancellationToken cancellationToken, Uri httpProxy, bool skipCertificateValidation, Uri authorizationUrl)
-            : base(cloudTarget, cancellationToken, httpProxy, skipCertificateValidation, authorizationUrl)
+            : base(cloudTarget, cancellationToken, httpProxy, skipCertificateValidation, authorizationUrl, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CloudFoundryClient" /> class.
+        /// </summary>
+        /// <param name="cloudTarget">The cloud target.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="httpProxy">The HTTP proxy.</param>
+        /// <param name="skipCertificateValidation">if set to <c>true</c> it will skip TLS certificate validation for HTTP requests.</param>
+        /// <param name="authorizationUrl">Authorization Endpoint</param>
+        /// <param name="useStrictStatusCodeChecking">throw exception if the successful http status code returned from the server does not match the expected code</param>
+        public CloudFoundryClient(Uri cloudTarget, CancellationToken cancellationToken, Uri httpProxy, bool skipCertificateValidation, Uri authorizationUrl, bool useStrictStatusCodeChecking)
+            : base(cloudTarget, cancellationToken, httpProxy, skipCertificateValidation, authorizationUrl, useStrictStatusCodeChecking)
         {
             this.V2 = new V2.Client.CloudFoundryClient(cloudTarget, cancellationToken, httpProxy, skipCertificateValidation);
         }


### PR DESCRIPTION
Use a parameter to specify if the client should throw an exception when the http status code is not the expected one.